### PR TITLE
Resolved unbounded variable issue and Cmake now works properly

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,8 +3,8 @@
 set -exuo pipefail
 
 echo "Checking Compiler and Build System"
-command -v cmake &>/dev/null && CMAKE_PRESENT=1
-command -v curl &>/dev/null && CURL_PRESENT=1
+command -v cmake &>/dev/null && CMAKE_PRESENT=1 || CMAKE_PRESENT=0
+command -v curl &>/dev/null && CURL_PRESENT=1 || CURL_PRESENT=0
 
 error() {
 	echo "Error: $1, build stopping, probably dependencies could not be downloaded."
@@ -46,13 +46,13 @@ download_from_github() {
 }
 
 download_cmake() {
-	repo="kitware/cmake"
-	version="$(get_latest_release $repo)"
-	download_from_github "$repo" "$version" "cmake-${version#"v"}-macos-universal.dmg" || return 1
-	echo "Unknown command quitting on purpose" && return 0
-	MOUNTED_CMAKE_PATH="$(yes | hdiutil attach cmake-${version#"v"}-macos-universal.dmg | tail -n 1 | cut -d$'\t' -f 3)"
-	export PATH="$MOUNTED_CMAKE_PATH/CMake.app/Contents/bin":"$PATH"
-	# TODO: CLEANUP see cleanup functions
+  repo="kitware/cmake"
+  version="$(get_latest_release $repo)"
+  download_from_github "$repo" "$version" "cmake-${version#"v"}-macos-universal.dmg" || return 1
+  MOUNTED_CMAKE_PATH="$(yes | hdiutil attach cmake-${version#"v"}-macos-universal.dmg | tail -n 1 | cut -d$'\t' -f 3)"
+  export PATH="$MOUNTED_CMAKE_PATH/CMake.app/Contents/bin":"$PATH"
+  hdiutil detach "$MOUNTED_CMAKE_PATH"
+  # TODO: CLEANUP see cleanup functions
 }
 
 
@@ -221,3 +221,4 @@ post_build() {
 
 # If cmake is present then use it
 download_dependencies && extract_deps "$LOC/dependencies/runtime" && install_deps && build_meta && make_metacallcli && post_build && make_tarball && cleanup && exit 0
+

--- a/build.sh
+++ b/build.sh
@@ -46,13 +46,13 @@ download_from_github() {
 }
 
 download_cmake() {
-  repo="kitware/cmake"
-  version="$(get_latest_release $repo)"
-  download_from_github "$repo" "$version" "cmake-${version#"v"}-macos-universal.dmg" || return 1
-  MOUNTED_CMAKE_PATH="$(yes | hdiutil attach cmake-${version#"v"}-macos-universal.dmg | tail -n 1 | cut -d$'\t' -f 3)"
-  export PATH="$MOUNTED_CMAKE_PATH/CMake.app/Contents/bin":"$PATH"
-  hdiutil detach "$MOUNTED_CMAKE_PATH"
-  # TODO: CLEANUP see cleanup functions
+	repo="kitware/cmake"
+	version="$(get_latest_release $repo)"
+	download_from_github "$repo" "$version" "cmake-${version#"v"}-macos-universal.dmg" || return 1
+	MOUNTED_CMAKE_PATH="$(yes | hdiutil attach cmake-${version#"v"}-macos-universal.dmg | tail -n 1 | cut -d$'\t' -f 3)"
+	export PATH="$MOUNTED_CMAKE_PATH/CMake.app/Contents/bin":"$PATH"
+	hdiutil detach "$MOUNTED_CMAKE_PATH"
+	# TODO: CLEANUP see cleanup functions
 }
 
 


### PR DESCRIPTION
This version of code removes the echo statement that was preventing the rest of the code from executing, and adds a line to detach the mounted disk image at the end to ensure that the system is left in a clean state.
Also the unbounded variables are now made bounded by assigning them non null values.